### PR TITLE
chore(deps): consolidate Dependabot updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-config-prettier": "^9.1.2",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-n": "^18.3.0",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-promise": "^6.6.0",
     "eslint-plugin-standard": "^5.0.0",
@@ -63,6 +63,12 @@
     "hooks": {
       "pre-commit": "npm run lint:staged",
       "pre-push": "npm run lint && npm run test"
+    }
+  },
+  "//": "eslint-config-standard@17.1.0 is its final release and peer-pins eslint-plugin-n to ^15||^16. The rules it uses all still exist and fire on eslint-plugin-n 18, so this override corrects stale peer metadata rather than forcing an incompatible version. See #160.",
+  "overrides": {
+    "eslint-config-standard": {
+      "eslint-plugin-n": "$eslint-plugin-n"
     }
   }
 }


### PR DESCRIPTION
Consolidates this repository's open Dependabot PRs into a single reviewable change.

Closes #160

## Included updates (npm_and_yarn)

| Package | From | To | Bump | Supersedes | Status |
|---------|------|----|------|------------|--------|
| `eslint-plugin-n` (dev) | ^16.6.2 | ^18.3.0 | major | #156 | ✅ pass |

**Nothing in `dependencies` or `peerDependencies` moved.** This is a published library, so
that matters: `fastify-plugin@^4.0.0`, `uuid@^10.0.0` and `peerDependencies.mercurius@^13.0.0`
are untouched, and there is no semver implication for consumers. The only change is a
devDependency and a dev-only `overrides` entry (npm `overrides` are not honoured for
consumers of a published package).

## Why the `overrides` entry is needed

`eslint-plugin-n@17+` cannot be installed without it. `eslint-config-standard@17.1.0` — which
`.eslintrc` extends, and which is that package's **final release** (published 2023, no newer
version exists) — declares:

```
peerDependencies: { "eslint-plugin-n": "^15.0.0 || ^16.0.0" }
```

CI runs a plain `npm install`, so this is a hard failure, not a warning. Reproduced from a
clean tree on this repo before the override was added:

```
npm error code ERESOLVE
npm error Found: eslint-plugin-n@17.24.0
npm error Could not resolve dependency:
npm error peer eslint-plugin-n@"^15.0.0 || ^16.0.0 " from eslint-config-standard@17.1.0
```

This is why #156 has sat open since August 2024.

### The override is peer-metadata lag, and that was proven rather than assumed

An `overrides` entry is a claim that the package works outside its declared peer range, so
here is the evidence. `eslint-config-standard@17.1.0` uses exactly seven `n/` rules. All seven
still exist in `eslint-plugin-n@18.3.0`, and six of them were exercised against a fixture
written to trip them (`n/process-exit-as-throw` only alters `no-unreachable` reporting and has
no directly observable message):

```
n/handle-callback-err    PRESENT   fired
n/no-callback-literal    PRESENT   fired
n/no-deprecated-api      PRESENT   fired
n/no-exports-assign      PRESENT   fired
n/no-new-require         PRESENT   fired
n/no-path-concat         PRESENT   fired
n/process-exit-as-throw  PRESENT   (no directly observable message)
```

A green `npm run lint` on this repo's six files would not have proven this on its own — the
repo is clean, so no `n/` rule fires during a normal run.

The override resolves to a single hoisted copy, not a nested duplicate:

```
├─┬ eslint-config-standard@17.1.0
│ └── eslint-plugin-n@18.3.0 deduped
└── eslint-plugin-n@18.3.0
```

## Why `^18.3.0` rather than Dependabot's `17.10.2`

Both targets need the identical override — `eslint-config-standard`'s peer range stops at 16
either way — so this is not a case of reaching higher to dodge a constraint. The deciding
factor is the dependency tree, measured on both:

| | tree entries (`npm ls --all`) | pulls in `typescript` |
|---|---|---|
| base (`^16.6.2`) | 829 | no |
| `^17.10.2` → resolves 17.24.0 | 845 | **yes — `typescript@7.0.2` + a native platform binary** |
| `^18.3.0` | **824** | no |

(All three rows were measured by actually installing each variant from a clean checkout of
`master`, with the same override applied, on the same npm.)

`eslint-plugin-n@17.24.0` added `ts-declaration-location` as a hard **dependency**, and that
package declares a non-optional `typescript: ">=4.0.0"` peer, so npm installs TypeScript 7 into
a repository that contains no TypeScript. `eslint-plugin-n@18` moved `ts-declaration-location`
and `typescript` to **optional** peers, so neither is installed. Since this repo has no
lockfile (`package-lock.json` is gitignored and CI runs `npm install`), `^17.10.2` would always
float to 17.24.0 in CI — the TypeScript pull-in is not avoidable by staying on Dependabot's
literal number.

`^18.3.0` therefore lands the bump with a tree five entries *smaller* than the base branch.
`eslint-plugin-n@18.3.0` requires `eslint >= 8.57.1`; this repo pins `eslint@^8.57.1`, so it is
satisfied. Its `engines.node` is `^20.19.0 || ^22.13.0 || >=24`, which all three CI matrix legs
(20, 22, 24) satisfy — verified by installs with no `EBADENGINE` warning on all three.

To be explicit about what is being asked for: this is two majors past the base and one past
Dependabot's target, and 18.3.0 was published 2026-08-08. Reviewers who would rather take the
in-scope number can say so — `^17.10.2` verifies green too, at the cost of the TypeScript 7
pull-in above. The `overrides` entry is required either way.

## Verification

Run locally on this branch. Node 24.18.0 / npm 11.16.0 unless noted.

- install (`npm install`, clean `node_modules`, matching what CI runs): ✅
- lint (`npm run lint`): ✅ — `eslint . --format json` reports the same 6 files traversed on both branches (`examples/basic.js`, `index.js`, `lib/queries.js`, `lib/util.js`, `test/index.test.js`, `test/util.test.js`); the file lists are byte-identical
- tests (`npm test` → `node --test`): ✅ 19 passed, 0 failed — identical counts to the base branch
- build: n/a — this project defines no build step
- `npm ls --all`: ✅ exit 0 (also exit 0 on the base branch)
- **All three CI matrix legs**, each from a clean checkout with its own `npm install`: Node 20.20.2 / npm 10.8.2 ✅, Node 22.19.0 / npm 10.9.3 ✅, Node 24.18.0 / npm 11.16.0 ✅ — install, lint and 19/19 tests on each, with no `EBADENGINE` warning on any
- Runtime smoke test: booted a Fastify server registering both `mercurius` and this plugin, and served a GraphQL query (`HTTP 200 {"data":{"hello":"ok"}}`). CI never starts a server, so a green suite alone would not prove the plugin still registers. It does — unsurprisingly, since no runtime dependency moved.

`ci.yml` also runs `fastify/github-action-merge-dependabot@v3`. That action skips any PR whose
author is not `dependabot[bot]`, so it will no-op here and this PR does not need to open as a
draft to avoid self-merging.

The base branch was baselined first (install / lint / test / `npm ls --all` all green, 19 tests
passing), so none of the above is absorbing a pre-existing failure and none of it claims credit
for a fix that was not made.

### Install-tree diff

This repo has no committed lockfile, so the change was proven with a name-keyed install-tree
comparison instead. Every package that moved is `eslint-plugin-n` or one of its transitives:

```
- eslint-plugin-n@16.6.2            + eslint-plugin-n@18.3.0
- builtins@5.1.0                    + enhanced-resolve@5.24.5
- builtin-modules@3.3.0             + globals@15.15.0
- is-builtin-module@3.2.1           + globrex@0.1.2
- resolve@1.22.12                   + graceful-fs@4.2.11
                                    + tapable@2.3.3
                                    + ts-declaration-location@?   (unmet optional peer)
                                    + typescript@?                (unmet optional peer)
```

The last two are `UNMET OPTIONAL DEPENDENCY` rows under `eslint-plugin-n`, not installs —
nothing lands in `node_modules` for either, which is precisely the difference from `^17` above.

`eslint-plugin-n@18` requires `globals@^15.11.0`, so it gets its own nested `globals@15.15.0`.
The hoisted root `globals@13.24.0` is unchanged and still hoisted in both trees; `npm ls`
merely prints its fully-expanded listing under `eslint` instead of under `eslint-plugin-n`,
which makes the tree diff look like a move when nothing moved.

No runtime dependency (`fastify-plugin`, `uuid`, `mercurius` and its subtree) changed position
or version.

## Closed as obsolete, not folded in

- **#133 — `tap` 16.3.9 → 18.6.1.** There is nothing to bump. `tap` was removed from the project
  in #157 (*"BREAKING CHANGE: remove tap in favour of node test runner"*) and `npm test` is now
  `node --test`. The PR predates that removal by nearly two years and its diff no longer applies
  to any dependency this project declares.

## Known and accepted

- `engines.node` is left at `">=20"`. `eslint-plugin-n@18` wants `^20.19.0 || ^22.13.0 || >=24`,
  so a contributor on Node 20.0–20.18, 21 or 23 would now see an `EBADENGINE` warning on
  `npm install`. It is a dev-tool floor only — `engines` is a statement about *consumers* of
  this package, no runtime dependency moved, and every CI leg is well clear of it — so raising
  it would be a consumer-facing change made for a lint plugin's benefit. Deliberately not done.
- The `overrides` entry is annotated with a `"//"` key in `package.json` so the reasoning
  survives outside this PR description.
- A leftover `.taprc` remains in the repo from the `tap` removal in #157. It is dead
  configuration and unrelated to any bump here, so it is deliberately left alone rather than
  widening this diff — worth a separate tidy-up.
- `npm audit` reports 6 vulnerabilities (2 moderate, 4 high) on this branch. It reports the same
  6 on the base branch; this change neither introduces nor fixes any of them.
- `eslint-config-standard` and `eslint-plugin-standard` are both unmaintained, and `eslint@8` is
  past end-of-life. The real long-term fix is a flat-config migration to `neostandard` with
  `eslint@9`. That is a migration, not a bump, and is out of scope here — this PR keeps the
  existing eslintrc setup working while landing the bump that was blocked by it.
